### PR TITLE
Potential fix for code scanning alert no. 1: Writable file handle closed without error handling

### DIFF
--- a/authutil/token_store.go
+++ b/authutil/token_store.go
@@ -30,13 +30,19 @@ func ReadTokenFile(fpath string) (*oauth2.Token, error) {
 }
 
 // WriteTokenFile writes a token file to the the filepaths.
-func WriteTokenFile(fpath string, tok *oauth2.Token) error {
+func WriteTokenFile(fpath string, tok *oauth2.Token) (err error) {
 	f, err := os.OpenFile(fpath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return errorsutil.Wrap(err, "Unable to write OAuth token")
 	}
-	defer f.Close()
-	return json.NewEncoder(f).Encode(tok)
+	defer func() {
+		cerr := f.Close()
+		if err == nil && cerr != nil {
+			err = cerr
+		}
+	}()
+	err = json.NewEncoder(f).Encode(tok)
+	return err
 }
 
 type TokenStoreFile struct {


### PR DESCRIPTION
Potential fix for [https://github.com/grokify/goauth/security/code-scanning/1](https://github.com/grokify/goauth/security/code-scanning/1)

To fix this issue, you should ensure that errors from `f.Close()` are checked and handled explicitly. The best way is to replace the defer statement with a deferred function that captures any error returned from `Close` and ensures the function returns it if none was already returned from encode. 

For the function `WriteTokenFile`, this means:
- Changing its signature to a named return value (e.g., `err error`).
- Using a deferred function to perform the file close and, if an error occurs from close and encode succeeded, ensure the close error is returned.
- Only edit lines within `WriteTokenFile` in `authutil/token_store.go`.
- No change to external functionality or logic, just additional error handling.
No new imports are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
